### PR TITLE
Update quarter naming and display period

### DIFF
--- a/Analyseur de performance V2.html
+++ b/Analyseur de performance V2.html
@@ -28,18 +28,18 @@
                 </div>
                 <div class="input-group">
                     <label for="typePeriode">Type de Période</label>
-                    <select id="typePeriode" onchange="changerTypePeriode()">
+                    <select id="typePeriode" onchange="changerTypePeriode();afficherPeriodeSelectionnee()">
                         <option value="mois">Mois</option>
                         <option value="trimestre">Trimestre</option>
                     </select>
                 </div>
                 <div class="input-group" id="groupeMois">
                     <label for="selectMois">Mois</label>
-                    <select id="selectMois"></select>
+                    <select id="selectMois" onchange="afficherPeriodeSelectionnee()"></select>
                 </div>
                 <div class="input-group" id="groupeTrimestre" style="display:none;">
                     <label for="selectTrimestre">Trimestre</label>
-                    <select id="selectTrimestre"></select>
+                    <select id="selectTrimestre" onchange="afficherPeriodeSelectionnee()"></select>
                 </div>
                 <div class="input-group" id="groupeProductivite">
                     <label for="tauxProductivite">Taux de Productivité (%)</label>
@@ -61,6 +61,7 @@
             <div class="export-zone">
                 <div class="screenshot-header">📊 Rapport de Performance - Équipe de Vente</div>
                 <div class="screenshot-date" id="reportDate"></div>
+                <div class="selected-period" id="selectedPeriod"></div>
             </div>
 
             <div class="section">

--- a/script.js
+++ b/script.js
@@ -13,8 +13,8 @@ function populatePeriodeSelects() {
         }
         for (let t = 1; t <= 4; t++) {
             const optT = document.createElement('option');
-            optT.value = `${year}-T${t}`;
-            optT.textContent = `${year} T${t}`;
+            optT.value = `${year}-Q${t}`;
+            optT.textContent = `${year} Q${t}`;
             selectTrimestre.appendChild(optT);
         }
     }
@@ -24,6 +24,18 @@ function changerTypePeriode() {
     const type = document.getElementById('typePeriode').value;
     document.getElementById('groupeMois').style.display = type === 'mois' ? 'flex' : 'none';
     document.getElementById('groupeTrimestre').style.display = type === 'trimestre' ? 'flex' : 'none';
+    afficherPeriodeSelectionnee();
+}
+
+function afficherPeriodeSelectionnee() {
+    const type = document.getElementById('typePeriode').value;
+    let texte = '';
+    if (type === 'mois') {
+        texte = document.getElementById('selectMois').value;
+    } else {
+        texte = document.getElementById('selectTrimestre').value.replace('-Q', ' Q');
+    }
+    document.getElementById('selectedPeriod').textContent = texte;
 }
 
 function getBelgiumHolidays(year) {
@@ -91,7 +103,7 @@ function ajouterVendeur() {
         startDate = new Date(year, month - 1, 1);
         endDate = new Date(year, month, 0);
     } else {
-        const [year, trimestre] = document.getElementById('selectTrimestre').value.split('-T');
+        const [year, trimestre] = document.getElementById('selectTrimestre').value.split('-Q');
         const startMonth = (parseInt(trimestre) - 1) * 3;
         startDate = new Date(parseInt(year), startMonth, 1);
         endDate = new Date(parseInt(year), startMonth + 3, 0);
@@ -608,5 +620,6 @@ function exporterCapture() {
 document.addEventListener('DOMContentLoaded', () => {
     populatePeriodeSelects();
     changerTypePeriode();
+    afficherPeriodeSelectionnee();
     mettreAJourAffichage(); // To set the initial empty state correctly
 });

--- a/style.css
+++ b/style.css
@@ -249,6 +249,14 @@
             margin-bottom: 30px;
         }
 
+        .selected-period {
+            text-align: center;
+            font-size: 1.8em;
+            font-weight: bold;
+            color: #2c3e50;
+            margin-bottom: 20px;
+        }
+
         @media print {
             .no-print {
                 display: none !important;


### PR DESCRIPTION
## Summary
- rename quarter dropdown options from T to Q
- show chosen period prominently

## Testing
- `npm test` *(fails: could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6842aa4e4900832bb4c7551cdd045c21