### PR TITLE
Add Excel import capability

### DIFF
--- a/Analyseur de performance Standalone.html
+++ b/Analyseur de performance Standalone.html
@@ -360,6 +360,16 @@
             <button class="btn" onclick="ajouterVendeur()">Ajouter Vendeur</button>
         </div>
 
+        <div class="section no-print">
+            <h2>📥 Importer depuis Excel</h2>
+            <div class="input-grid">
+                <div class="input-group">
+                    <input type="file" id="excelFile" accept=".xlsx,.xls">
+                </div>
+            </div>
+            <button class="btn" onclick="importerDepuisExcel()">Importer</button>
+        </div>
+
         <div id="exportZone">
             <div class="export-zone">
                 <div class="screenshot-header">📊 Rapport de Performance - Équipe de Vente</div>
@@ -544,8 +554,7 @@ function calculateWorkingDays(start, end) {
     return total;
 }
 
-function ajouterVendeur() {
-    const nom = document.getElementById('vendeurNom').value.trim();
+function getPeriodeDates() {
     const typePeriode = document.getElementById('typePeriode').value;
     let startDate, endDate;
     if (typePeriode === 'mois') {
@@ -567,6 +576,12 @@ function ajouterVendeur() {
         startDate = new Date(year, 0, 1);
         endDate = new Date(year, 11, 31);
     }
+    return { startDate, endDate };
+}
+
+function ajouterVendeur() {
+    const nom = document.getElementById('vendeurNom').value.trim();
+    const { startDate, endDate } = getPeriodeDates();
 
     const tauxProductivite = parseFloat(document.getElementById('tauxProductivite').value) || 100;
     const totalClients = parseInt(document.getElementById('totalClients').value) || 0;
@@ -605,6 +620,52 @@ function ajouterVendeur() {
     document.getElementById('totalPoints').value = '';
 
     mettreAJourAffichage();
+}
+
+function importerDepuisExcel() {
+    const fileInput = document.getElementById('excelFile');
+    if (!fileInput || fileInput.files.length === 0) {
+        alert('Veuillez sélectionner un fichier Excel.');
+        return;
+    }
+    const file = fileInput.files[0];
+    const reader = new FileReader();
+    reader.onload = function(e) {
+        const data = new Uint8Array(e.target.result);
+        const workbook = XLSX.read(data, { type: 'array' });
+        const sheet = workbook.Sheets[workbook.SheetNames[0]];
+        const rows = XLSX.utils.sheet_to_json(sheet, { header: 1 });
+        for (let i = 1; i < rows.length; i++) {
+            const row = rows[i];
+            if (!row || !row[0]) continue;
+            const nom = String(row[0]).trim();
+            const tauxProductivite = parseFloat(row[1]) || 100;
+            const totalClients = parseInt(row[2]) || 0;
+            const totalPoints = parseInt(row[3]) || 0;
+
+            const { startDate, endDate } = getPeriodeDates();
+            const joursTravaillables = calculateWorkingDays(startDate, endDate);
+            const joursReelsTravaill = Math.max(1, joursTravaillables * (tauxProductivite / 100));
+            const clientsParJour = parseFloat((totalClients / joursReelsTravaill).toFixed(2));
+            const pointsParJour = parseFloat((totalPoints / joursReelsTravaill).toFixed(2));
+            const pointsParClient = parseFloat((totalClients > 0 ? totalPoints / totalClients : 0).toFixed(2));
+
+            vendeurs.push({
+                nom,
+                joursTravaillables,
+                tauxProductivite,
+                joursReelsTravaill,
+                totalClients,
+                totalPoints,
+                clientsParJour,
+                pointsParJour,
+                pointsParClient
+            });
+        }
+        mettreAJourAffichage();
+        fileInput.value = '';
+    };
+    reader.readAsArrayBuffer(file);
 }
 
 function supprimerVendeur(index) {

--- a/Analyseur de performance V2.html
+++ b/Analyseur de performance V2.html
@@ -66,7 +66,18 @@
                     <input type="number" id="totalPoints" placeholder="Ex: 2500" min="0">
                 </div>
             </div>
+
             <button class="btn" onclick="ajouterVendeur()">Ajouter Vendeur</button>
+        </div>
+
+        <div class="section no-print">
+            <h2>📥 Importer depuis Excel</h2>
+            <div class="input-grid">
+                <div class="input-group">
+                    <input type="file" id="excelFile" accept=".xlsx,.xls">
+                </div>
+            </div>
+            <button class="btn" onclick="importerDepuisExcel()">Importer</button>
         </div>
 
         <div id="exportZone">

--- a/README.md
+++ b/README.md
@@ -8,3 +8,6 @@ Pour une version autonome, ouvrez directement `Analyseur de performance Standalo
 Les styles sont désormais dans `style.css` et la logique dans `script.js`.
 
 Vous pouvez choisir de calculer la performance à partir des jours d'absence ou d'un pourcentage de productivité.
+Il est également possible d'importer un fichier Excel contenant les colonnes
+`Nom du Vendeur`, `Taux de Productivité (%)`, `Total Clients Servis` et
+`Total Points Réalisés` pour renseigner automatiquement les vendeurs.


### PR DESCRIPTION
## Summary
- let users upload an Excel file to auto-fill sellers
- compute date ranges in a new helper `getPeriodeDates`
- document Excel import usage

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6842c2765504832babb71f7d1e456b8d